### PR TITLE
change PWP::Encoding to PWP::SingleEncoding

### DIFF
--- a/lib/Pod/Weaver/PluginBundle/BioPerl.pm
+++ b/lib/Pod/Weaver/PluginBundle/BioPerl.pm
@@ -66,8 +66,8 @@ equivalent to:
   [Legal::Complicated]
   [Contributors]
 
-  [-Encoding]
-  encoding = utf-8
+  [-SingleEncoding]
+  encoding = UTF-8
 
   [-Transformer]
   transformer = List
@@ -109,7 +109,7 @@ sub mvp_bundle_config {
     ['@BioPerl/Legal',     _exp('Legal::Complicated'), {}                                    ],
     ['@BioPerl/Contributors', _exp('Contributors'), {}                                       ],
 
-    ['Encoding',           _exp('-Encoding'),       { encoding => 'utf-8' }  ],
+    ['SingleEncoding',     _exp('-SingleEncoding'), { encoding => 'UTF-8' }  ],
 
     ['@BioPerl/List',      _exp('-Transformer'),    { transformer => 'List'} ],
 


### PR DESCRIPTION
Hi,

`Pod::Weaver` now has`SingleEncoding` plugin (starting from 4.000), which makes `Pod::Weaver::Plugin::Encoding` an extra dependency that could be thrown away.

See [Rik's post](http://rjbs.manxome.org/rubric/entry/2021) and also check out my quest for details/comments:

> http://questhub.io/realm/perl/quest/5277f3cc9f567ad56f0000e7

Cheers,
Sergey